### PR TITLE
Include sub-techniques in technique filtering

### DIFF
--- a/src/attack_flow_builder/src/assets/scripts/OpenChart/DiagramModel/DiagramObject/Property/CollectionProperty/TupleProperty/CombinationIndex.ts
+++ b/src/attack_flow_builder/src/assets/scripts/OpenChart/DiagramModel/DiagramObject/Property/CollectionProperty/TupleProperty/CombinationIndex.ts
@@ -90,7 +90,10 @@ export class CombinationIndex {
             // Add relationships to results matrix
             const valueIdx = this.values.get(valueId)!;
             for (const rel of this.lookup[valueIdx]) {
-                const [prop, value] = idxToId[rel].split(/\./g);
+                const id = idxToId[rel];
+                const splitIdx = id.indexOf(".");
+                const prop = id.substring(0, splitIdx);
+                const value = id.substring(splitIdx + 1);
                 matrix.get(prop)![i].add(value);
             }
             i++;


### PR DESCRIPTION
## Summary
- Preserve sub-technique identifiers during relation lookups so tactic-based filtering surfaces all relevant techniques

## Testing
- `npm run lint`
- `npm run test:unit`
- `pytest` *(fails: ModuleNotFoundError: No module named 'stix2')*


------
https://chatgpt.com/codex/tasks/task_e_6897303e26408323a5c025c5191cf736